### PR TITLE
Parallax Scrolling now event based

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -76,11 +76,11 @@ function App() {
         <InfoDelivery />
       </div>
       <div className="App" style={{ width: '100vw', height: '100vh' }}>
-        <Ticket isActive={pageIndex === 11} />
+        <Ticket pageIndex={11} />
       </div>
       <div className="App" style={{ width: '100vw', height: '100vh' }}>
         <Ticket
-          isActive={pageIndex === 12}
+          pageIndex={12}
           bottomTicket
           subtext="The tread depths (in 32nd inch) of each individual tire is also calculated and displayed."
           dataHeader="Average tire depth: "

--- a/src/components/Navigation/Navigation.js
+++ b/src/components/Navigation/Navigation.js
@@ -20,14 +20,20 @@ function Navigation(props) {
   const pageUp = () => {
     if (pageIndex > 0) {
       changePageIndex(pageIndex - 1);
+      const scrollevent = new CustomEvent('page-scroll', { detail: pageIndex - 1 });
+      document.dispatchEvent(scrollevent);
     }
   };
 
   const pageDown = () => {
     if (pageIndex < maxPages) {
       changePageIndex(pageIndex + 1);
+      const scrollevent = new CustomEvent('page-scroll', { detail: pageIndex + 1 });
+      document.dispatchEvent(scrollevent);
     } else {
       changePageIndex(0);
+      const scrollevent = new CustomEvent('page-scroll', { detail: 0 });
+      document.dispatchEvent(scrollevent);
     }
   };
 

--- a/src/components/Pages/Ticket/CarComponent.js
+++ b/src/components/Pages/Ticket/CarComponent.js
@@ -12,7 +12,7 @@ function CarComponent(props) {
   const [componentWidth, setCompWidth] = useState(window.innerWidth * 0.3166053511705686);
   const [componentHeight, setCompHeight] = useState(window.innerHeight * 0.5837486687965922);
 
-  const { isActive, n1, n2, n3, n4, tireDepthCar, heightPct } = props;
+  const { pageIndex, n1, n2, n3, n4, tireDepthCar, heightPct } = props;
 
   function resetLines() {
     setBoxWidth(window.innerWidth * 0.0611430625);
@@ -43,7 +43,7 @@ function CarComponent(props) {
       <div className="ticket-car-box" style={{ right: 0, bottom: 0 }}>
         <p>{n4}</p>
       </div>
-      <ParallaxComponent shouldParallaxScroll={isActive} transitionTime={2000} transitionDelay={0}>
+      <ParallaxComponent pageIndex={pageIndex} transitionTime={2000} transitionDelay={0}>
         <img src={tireDepthCar ? tireCar : psiCar} alt="Car with Tire Pressure in PSI" />
       </ParallaxComponent>
       <svg>
@@ -72,7 +72,7 @@ function CarComponent(props) {
 }
 
 CarComponent.propTypes = {
-  isActive: PropTypes.bool,
+  pageIndex: PropTypes.number,
   n1: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   n2: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   n3: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
@@ -82,7 +82,7 @@ CarComponent.propTypes = {
 };
 
 CarComponent.defaultProps = {
-  isActive: false,
+  pageIndex: -2,
   n1: 32,
   n2: 27,
   n3: 29,

--- a/src/pages/Ticket.js
+++ b/src/pages/Ticket.js
@@ -5,17 +5,17 @@ import ParallaxComponent from '../components/Parallax/ParallaxComponent';
 import CarComponent from '../components/Pages/Ticket/CarComponent';
 
 function Ticket(props) {
-  const { isActive, bottomTicket, subtext, dataHeader, data, note } = props;
+  const { bottomTicket, subtext, dataHeader, data, note, pageIndex } = props;
   return (
     <div className="ticket-background">
-      <ParallaxComponent shouldParallaxScroll={isActive} transitionTime={1500} transitionDelay={0}>
+      <ParallaxComponent pageIndex={pageIndex} transitionTime={1500} transitionDelay={0}>
         <div className="split ticket-img-box">
           <div className={`ticket-box ticket-box-${bottomTicket ? 'bottom' : 'top'}`}>
             {!bottomTicket ? <div className="ticket-loop" /> : <div className="ticket-offset" />}
             {bottomTicket ? (
-              <CarComponent isActive={isActive} tireDepthCar heightPct={70} n1={7} n2={10} n3="> 6" n4={9} />
+              <CarComponent pageIndex={pageIndex} tireDepthCar heightPct={70} n1={7} n2={10} n3="> 6" n4={9} />
             ) : (
-              <CarComponent isActive={isActive} />
+              <CarComponent pageIndex={pageIndex} />
             )}
           </div>
         </div>
@@ -39,7 +39,7 @@ function Ticket(props) {
 }
 
 Ticket.propTypes = {
-  isActive: PropTypes.bool,
+  pageIndex: PropTypes.number,
   bottomTicket: PropTypes.bool,
   subtext: PropTypes.string,
   dataHeader: PropTypes.string,
@@ -48,7 +48,7 @@ Ticket.propTypes = {
 };
 
 Ticket.defaultProps = {
-  isActive: false,
+  pageIndex: -2,
   bottomTicket: false,
   subtext: 'The tire pressure (in PSI) of each individual tire is displayed.',
   dataHeader: 'Average tire pressure: ',


### PR DESCRIPTION
Resolves issue: https://github.com/GTBitsOfGood/the-ray/issues/27

I haven't fully tested this, but I would assume that making the parallax scrolling event-based will have decreased lag over rerendering each page that uses parallax scrolling.  Unfortunately, this will require changing all shouldParallaxScroll properties to pageIndex properties which likely exists in multiple places now in Colin's update with adding parallax scrolling to every page.  Hopefully, there will not be any more large changes to the parallax components.