### PR TITLE
Fix Android scrolling

### DIFF
--- a/src/components/Navigation/Navigation.js
+++ b/src/components/Navigation/Navigation.js
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 
-import ProgressBar from './progressBar';
 import NextArrow from './NextArrow';
 import AutoplayArrow from './AutoplayArrow';
 
@@ -9,7 +8,7 @@ const TOUCH_START_TYPE = 'touchstart';
 const TOUCH_END_TYPE = 'touchend';
 
 function Navigation(props) {
-  const { children, progressBarColor, transitionTime, pageIndex, changePageIndex } = props;
+  const { children, transitionTime, pageIndex, changePageIndex } = props;
 
   const [isScrolling, changeScrollState] = useState(false);
 
@@ -172,14 +171,12 @@ function Navigation(props) {
           changeAutoplay(!isAutoplay);
         }}
       />
-      <ProgressBar bgcolor={progressBarColor} completed={(pageIndex / (Object.keys(children).length - 1)) * 100} />
     </div>
   );
 }
 
 Navigation.propTypes = {
   children: PropTypes.arrayOf(React.Component),
-  progressBarColor: PropTypes.string,
   transitionTime: PropTypes.number,
   pageIndex: PropTypes.number,
   changePageIndex: PropTypes.func,
@@ -187,7 +184,6 @@ Navigation.propTypes = {
 
 Navigation.defaultProps = {
   children: [],
-  progressBarColor: '#6a1b9a',
   transitionTime: 1000,
   pageIndex: 0,
   changePageIndex: () => {},

--- a/src/components/Navigation/Navigation.js
+++ b/src/components/Navigation/Navigation.js
@@ -5,6 +5,9 @@ import ProgressBar from './progressBar';
 import NextArrow from './NextArrow';
 import AutoplayArrow from './AutoplayArrow';
 
+const TOUCH_START_TYPE = 'touchstart';
+const TOUCH_END_TYPE = 'touchend';
+
 function Navigation(props) {
   const { children, progressBarColor, transitionTime, pageIndex, changePageIndex } = props;
 
@@ -15,6 +18,8 @@ function Navigation(props) {
   const pageContainer = useRef(null);
 
   const [isAutoplay, changeAutoplay] = useState(false);
+
+  const [touchStart, setTouchStart] = useState({ startX: 0, startY: 0 });
 
   const pageTimes = [
     2000,
@@ -88,16 +93,33 @@ function Navigation(props) {
   const onScroll = (event) => {
     if (!isScrolling) {
       changeScrollState(true);
-
       if (event.deltaY < 0) {
         pageUp();
       } else {
         pageDown();
       }
-
       setTimeout(() => {
         changeScrollState(false);
-      }, transitionTime);
+      }, 1500);
+    }
+  };
+
+  const onMobileScroll = (event) => {
+    event.preventDefault();
+    if (event.type === TOUCH_START_TYPE) {
+      setTouchStart({ startX: event.touches[0].clientX, startY: event.touches[0].clientY });
+    } else if (event.type === TOUCH_END_TYPE) {
+      const { startY } = touchStart;
+      const endY = event.changedTouches[0].clientY;
+      const deltaY = endY - startY;
+
+      if (deltaY < -10) {
+        // Scroll Down
+        pageDown();
+      } else if (deltaY > 10) {
+        // Scroll Up
+        pageUp();
+      }
     }
   };
 
@@ -123,11 +145,11 @@ function Navigation(props) {
     <div
       style={{
         height: '100vh',
-        width: '100vw',
         overflow: 'hidden',
       }}
     >
       <div
+        className="navigation-container"
         ref={pageContainer}
         style={{
           height: '100%',
@@ -136,6 +158,8 @@ function Navigation(props) {
           outline: 'none',
         }}
         onWheel={onScroll}
+        onTouchEnd={onMobileScroll}
+        onTouchStart={onMobileScroll}
       >
         {children}
       </div>

--- a/src/components/Navigation/NextArrow.css
+++ b/src/components/Navigation/NextArrow.css
@@ -7,7 +7,7 @@
 
 .arrow-image {
   position: absolute;
-  left: 92.78%;
+  left: 80%;
   right: 3.08%;
   top: 86.56%;
   bottom: 6.82%;


### PR DESCRIPTION
## Fix Android scrolling

Issue Number(s): #106

What does this PR change and why?
* Allows scrolling to work in android
* Fix the issue where the page would scroll too much on one scroll by increasing debounce delay in `onScroll` in `Navigation.js`.

### Checklist

- [x]  Database schema docs have been updated or are not necessary
- [x]  Code follows design and style guidelines
- [x]  Code is commented with doc blocks
- [x]  Tests have been written and executed or are not necessary
- [x]  Latest code has been rebased from base branch (usually `develop`)
- [x]  Commits follow guidelines (concise, squashed, etc)
- [x]  Github issues have been linked in relevant commits
- [x]  Relevant reviewers (Senior Dev/EM/Designers) have been assigned to this PR

### Critical Changes

- None

### Related PRs

- None

### How to Test

1. `npm i; npm run start`
2. Click on either options in the main page
3. Set browser to responsive mode and select some phone (`cmd + option + m` for mac)
4. Try scrolling
5. Try touch scrolling (click and scroll)
6. Bug Luke if it fails

### Potential Future Issues 
1. Scrolling rapidly twice on an actual phone fails to render the animation properly. If scrolls have a 1.5-second delay between one another, it doesn't do this.
